### PR TITLE
Fix: Pass --font-render-hinting=none so headless-shell PNG exports match across platforms

### DIFF
--- a/src/lib/tldraw-controller.ts
+++ b/src/lib/tldraw-controller.ts
@@ -221,6 +221,15 @@ export default class TldrawController {
 	async start() {
 		// Set up Puppeteer
 		log.info('Starting Puppeteer...')
+
+		// The `chrome-headless-shell` binary used by `headless: 'shell'` applies
+		// font hinting on Linux that nudges text metrics a few pixels relative to
+		// macOS and Windows. Since exports are sized to their content's bounding
+		// box, that shift changes the output dimensions and breaks the
+		// cross-platform image snapshot comparisons in CI. Disabling hinting
+		// realigns Linux output with the other platforms.
+		const platformArgs = process.platform === 'linux' ? ['--font-render-hinting=none'] : []
+
 		this.browser = await puppeteer.launch({
 			args: this.isLocal
 				? [
@@ -228,6 +237,7 @@ export default class TldrawController {
 						'--disable-web-security',
 						'--disable-setuid-sandbox',
 						'--disable-component-update',
+						...platformArgs,
 						// TODO these Don't really make a dent?
 						// '--disable-background-networking',
 						// '--disable-default-apps',
@@ -243,6 +253,7 @@ export default class TldrawController {
 						'--disable-web-security',
 						'--disable-setuid-sandbox',
 						'--disable-component-update',
+						...platformArgs,
 					],
 			headless: 'shell',
 		})

--- a/src/lib/tldraw-controller.ts
+++ b/src/lib/tldraw-controller.ts
@@ -222,14 +222,14 @@ export default class TldrawController {
 		// Set up Puppeteer
 		log.info('Starting Puppeteer...')
 
-		// The `chrome-headless-shell` binary used by `headless: 'shell'` applies
-		// font hinting on Linux that nudges text metrics a few pixels relative to
-		// macOS and Windows. Since exports are sized to their content's bounding
-		// box, that shift changes the output dimensions and breaks the
-		// cross-platform image snapshot comparisons in CI. Disabling hinting
-		// realigns Linux output with the other platforms.
-		const platformArgs = process.platform === 'linux' ? ['--font-render-hinting=none'] : []
-
+		// `chrome-headless-shell` (headless: 'shell') defaults to more aggressive
+		// font hinting than the new headless Chrome, which on Linux snaps glyphs to
+		// the pixel grid and shrinks tldraw's auto-sized text bounding box by a few
+		// pixels — changing export dimensions and breaking the cross-platform image
+		// snapshots. `--font-render-hinting=none` disables that. The flag only
+		// affects Chromium's FreeType (Linux) path; macOS (CoreText) and Windows
+		// (DirectWrite) ignore it, so it's safe to apply everywhere with no per-OS
+		// branching.
 		this.browser = await puppeteer.launch({
 			args: this.isLocal
 				? [
@@ -237,7 +237,7 @@ export default class TldrawController {
 						'--disable-web-security',
 						'--disable-setuid-sandbox',
 						'--disable-component-update',
-						...platformArgs,
+						'--font-render-hinting=none',
 						// TODO these Don't really make a dent?
 						// '--disable-background-networking',
 						// '--disable-default-apps',
@@ -253,7 +253,7 @@ export default class TldrawController {
 						'--disable-web-security',
 						'--disable-setuid-sandbox',
 						'--disable-component-update',
-						...platformArgs,
+						'--font-render-hinting=none',
 					],
 			headless: 'shell',
 		})


### PR DESCRIPTION
## Problem

After switching the export browser from `headless: true` to `headless: 'shell'` (285f968), every PNG image-snapshot test failed **on Ubuntu only** — macOS and Windows stayed green. Each failure reported `SSIM Score 0.0000 / Difference 100.00%`, even though the rendered images look identical to the eye.

## Root cause

The "100% difference" is misleading. The Ubuntu output is visually identical to the baseline but its **dimensions** differ by a few pixels:

| Snapshot | Baseline (macOS) | Ubuntu (`headless: 'shell'`) |
| --- | --- | --- |
| `…export-local-tldr-file-to-a-png` | 1489×1008 | 1486×1008 |
| `…with-scale-4` | 2979×2015 | 2972×2015 |

`headless: true` is the **new** headless — the full Chrome binary that shares Chrome's rendering code. `headless: 'shell'` is the separate legacy `chrome-headless-shell` binary, and the two inherit **different font-hinting defaults**. On Linux, the shell applies more aggressive hinting that snaps glyphs to the pixel grid, shrinking tldraw's auto-sized text bounding box by ~3px. Since exports are sized to that bounding box, the PNG comes out narrower — and the blazediff SSIM matcher treats *any* dimension mismatch as a total failure:

```js
// @blazediff/matcher
if (e.width !== t.width || e.height !== t.height) return { score: 0 }
```

So a sub-pixel text-metric difference — far below the 1% SSIM tolerance the test was designed around — short-circuits to a 100% failure.

## Fix

Pass `--font-render-hinting=none` to Chrome, applied **uniformly on every platform** (no per-OS branching). This disables the divergent hinting so `chrome-headless-shell` produces the same text metrics as the new headless Chrome (and as macOS/Windows), restoring the 1489px width.

Crucially, `--font-render-hinting` only feeds Chromium's **FreeType (Linux)** font path. macOS renders via **CoreText** and Windows via **DirectWrite**, neither of which this flag controls — so it is a **no-op on macOS/Windows** and leaves their already-passing output untouched. That's why a single universal flag is equivalent to (but cleaner than) a `process.platform === 'linux'` guard.

This keeps the `headless: 'shell'` performance win and does **not** loosen the strict 1% SSIM threshold.

### Why keep `headless: 'shell'`?

`chrome-headless-shell` is legacy but **actively maintained** — since Chrome 132 it ships as a standalone binary built for every Chrome release, purpose-built for lightweight/fast automation. The alternative, moving to `headless: true`, would give full real-Chrome fidelity and render consistently with no font flags, but it's structurally slower (the gap can't be fully closed with flags) and would likely require regenerating the baseline. We chose to keep the shell's speed; the new-headless route remains the natural future option if fidelity ever outweighs the speed win.

## Verification (reproduced on Linux)

- Before: all 7 PNG snapshot tests in `tldr-to-image.test.ts` fail with 100% difference (output width 1486px).
- After: width back to 1489px and **all 7 pass** under the existing 1% SSIM threshold.
- Confirmed the divergence is specific to `headless: 'shell'`: temporarily reverting to `headless: true` on Linux also makes output match exactly.
- Confirmed only `--font-render-hinting=none` is needed (`--disable-lcd-text` / `--disable-font-subpixel-positioning` were unnecessary and slightly worse).
- `pnpm run lint` passes (all 8 checks).

The macOS/Windows legs of CI on this PR are the cross-platform gate: they must still pass against the same shared baseline, confirming the flag is a no-op there.

> Note: `url-to-image.test.ts` (remote-asset) cases can't be exercised in the sandbox (no external network) but don't do pixel snapshotting and are unaffected.

Refs: developer.chrome.com/docs/chromium/headless · pptr.dev/guides/headless-modes · crbug 744577 · puppeteer#2410

https://claude.ai/code/session_017RP1LNyAzwYv2Aod1UpMui